### PR TITLE
Add support for favorite level and fix speed change

### DIFF
--- a/lib/devices/air-purifier-3.js
+++ b/lib/devices/air-purifier-3.js
@@ -183,6 +183,21 @@ module.exports = class extends AirPurifier.with(
 				}
 			}
 		);
+		
+		// Favorite Level
+		this.defineProperty(
+			{ did: `${id}`, siid: 10, piid: 10 },
+			{
+				name: 'favorite_level',
+				mapper: v => {
+					const { siid, piid } = v;
+
+					if (siid === 10 && piid === 10) {
+						return v.value;
+					}
+				}
+			}
+		);
 	}
 
 	changePower(value) {

--- a/lib/devices/air-purifier-3.js
+++ b/lib/devices/air-purifier-3.js
@@ -184,7 +184,7 @@ module.exports = class extends AirPurifier.with(
 			}
 		);
 		
-		// Favorite Level
+		// Favorite Fan Level
 		this.defineProperty(
 			{ did: `${id}`, siid: 10, piid: 10 },
 			{
@@ -275,12 +275,12 @@ module.exports = class extends AirPurifier.with(
 		const { id } = this.handle.api;
 		let value = parseInt(speed);
 
-		if (value < 390) {
-			value = 390;
+		if (value < 300) {
+			value = 300;
 		}
 
-		if (value > 2150) {
-			value = 2150;
+		if (value > 2300) {
+			value = 2300
 		}
 
 		return this.call('set_properties', [
@@ -330,7 +330,7 @@ module.exports = class extends AirPurifier.with(
 		]).then(() => null);
 	}
 	
-	changeFavorite(level) {
+	changeFavoriteLevel(level) {
 		const { id } = this.handle.api;
 		let value = parseInt(level);
 

--- a/lib/devices/air-purifier-3.js
+++ b/lib/devices/air-purifier-3.js
@@ -198,6 +198,21 @@ module.exports = class extends AirPurifier.with(
 				}
 			}
 		);
+		
+		// Motor Speed
+		this.defineProperty(
+			{ did: `${id}`, siid: 10, piid: 8 },
+			{
+				name: 'motor_speed',
+				mapper: v => {
+					const { siid, piid } = v;
+
+					if (siid === 10 && piid === 8) {
+						return v.value;
+					}
+				}
+			}
+		);
 	}
 
 	changePower(value) {

--- a/lib/devices/air-purifier-3.js
+++ b/lib/devices/air-purifier-3.js
@@ -316,4 +316,21 @@ module.exports = class extends AirPurifier.with(
 			{ did: `${id}`, siid: 5, piid: 1, value: !!value }
 		]).then(() => null);
 	}
+	
+	favoriteLevel(level=undefined) {
+		if(typeof level === 'undefined') {
+			return Promise.resolve(this.property('favoriteLevel'));
+		}
+
+		return this.setFavoriteLevel(level);
+	}
+	
+	/**
+	 * Set the favorite level used when the mode is `favorite`, should be
+	 * between 0 and 16.
+	 */
+	setFavoriteLevel(level) {
+		return this.call('changeFavorite', [ level ])
+			.then(() => null);
+	}
 };

--- a/lib/devices/air-purifier-3.js
+++ b/lib/devices/air-purifier-3.js
@@ -256,7 +256,7 @@ module.exports = class extends AirPurifier.with(
 		]);
 	}
 
-	changeFavorite(speed) {
+	changeSpeed(speed) {
 		const { id } = this.handle.api;
 		let value = parseInt(speed);
 
@@ -269,8 +269,6 @@ module.exports = class extends AirPurifier.with(
 		}
 
 		return this.call('set_properties', [
-			{ did: `${id}`, siid: 10, piid: 7, value },
-			{ did: `${id}`, siid: 10, piid: 8, value },
 			{ did: `${id}`, siid: 10, piid: 9, value }
 		]);
 	}
@@ -317,20 +315,20 @@ module.exports = class extends AirPurifier.with(
 		]).then(() => null);
 	}
 	
-	favoriteLevel(level=undefined) {
-		if(typeof level === 'undefined') {
-			return Promise.resolve(this.property('favoriteLevel'));
+	changeFavorite(level) {
+		const { id } = this.handle.api;
+		let value = parseInt(level);
+
+		if (value < 0) {
+			value = 0;
 		}
 
-		return this.setFavoriteLevel(level);
-	}
-	
-	/**
-	 * Set the favorite level used when the mode is `favorite`, should be
-	 * between 0 and 16.
-	 */
-	setFavoriteLevel(level) {
-		return this.call('changeFavorite', [ level ])
-			.then(() => null);
+		if (value > 14) {
+			value = 14;
+		}
+
+		return this.call('set_properties', [
+			{ did: `${id}`, siid: 10, piid: 10, value }
+		]);
 	}
 };

--- a/lib/devices/air-purifier-3.js
+++ b/lib/devices/air-purifier-3.js
@@ -271,7 +271,7 @@ module.exports = class extends AirPurifier.with(
 		]);
 	}
 
-	changeSpeed(speed) {
+	changeFavoriteSpeed(speed) {
 		const { id } = this.handle.api;
 		let value = parseInt(speed);
 
@@ -284,7 +284,7 @@ module.exports = class extends AirPurifier.with(
 		}
 
 		return this.call('set_properties', [
-			{ did: `${id}`, siid: 10, piid: 9, value }
+			{ did: `${id}`, siid: 10, piid: 7, value }
 		]);
 	}
 


### PR DESCRIPTION
piid 8 (motor1-speed) is not writable as per spec and seems to just report motor speed. It now seems possible to directly change favorite mode motor speed via piid 7 (m1-favorite).

Propose

1. renaming current changeFavorite to changeFavoriteSpeed.
2. adding properties for motor_speed and favorite_level
3. defining new changeFavoriteLevel to directly set favorite_level


Relevant spec:
````
Service: siid 10: (motor-speed): 10 props, 0 actions
    * Property piid: 1 (m1-strong): (int32, unit: None) (acc: ['read', 'write'], value-list: [], value-range: [300, 2300, 10])
    * Property piid: 2 (m1-high): (int32, unit: None) (acc: ['read', 'write'], value-list: [], value-range: [300, 2300, 10])
    * Property piid: 3 (m1-med): (int32, unit: None) (acc: ['read', 'write'], value-list: [], value-range: [300, 2300, 10])
    * Property piid: 4 (m1-med-l): (int32, unit: None) (acc: ['read', 'write'], value-list: [], value-range: [300, 2300, 10])
    * Property piid: 5 (m1-low): (int32, unit: None) (acc: ['read', 'write'], value-list: [], value-range: [300, 2300, 10])
    * Property piid: 6 (m1-silent): (int32, unit: None) (acc: ['read', 'write'], value-list: [], value-range: [300, 2300, 10])
    * Property piid: 7 (m1-favorite): (int32, unit: None) (acc: ['read', 'write'], value-list: [], value-range: [300, 2300, 10])
    * Property piid: 8 (motor1-speed): (int32, unit: None) (acc: ['read'], value-list: [], value-range: [0, 3000, 1])
    * Property piid: 9 (motor1-set-speed): (int32, unit: None) (acc: ['read', 'write'], value-list: [], value-range: [0, 3000, 1])
    * Property piid: 10 (favorite fan level): (int32, unit: None) (acc: ['read', 'write'], value-list: [], value-range: [0, 14, 1])